### PR TITLE
Amended my (swm) twitter handle to be theonlyswmcc and not swmcc

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -22,7 +22,7 @@ join the `#pybelfast` group. Just say 'hi!'.
 
 ## Organisers
 [Paddy Carey](http://www.twitter.com/paddycarey) and [Stephen
-McCullough](http://www.twitter.com/swmcc) are the organisers, you can find them
+McCullough](http://www.twitter.com/theonlyswmcc) are the organisers, you can find them
 on the slack channel.
 
 ## About this site


### PR DESCRIPTION
My twitter handle changed from `swmcc` to `theonlyswmcc` for reasons.